### PR TITLE
bug: `render_json` doesn't pass kwargs

### DIFF
--- a/beet/toolchain/template.py
+++ b/beet/toolchain/template.py
@@ -153,9 +153,9 @@ class TemplateManager:
         if isinstance(data, str):
             return self.render_string(data, **kwargs)  # type: ignore
         elif isinstance(data, list):
-            return [self.render_json(element) for element in data]  # type: ignore
+            return [self.render_json(element, **kwargs) for element in data]  # type: ignore
         elif isinstance(data, dict):
-            return {key: self.render_json(value) for key, value in data.items()}  # type: ignore
+            return {key: self.render_json(value, **kwargs) for key, value in data.items()}  # type: ignore
         else:
             return data
 


### PR DESCRIPTION
Fixed by passing `**kwargs` to the recursive `render_json` calls.