### PR TITLE
feat: Project advancement plugin

### DIFF
--- a/beet/contrib/project_advancement.py
+++ b/beet/contrib/project_advancement.py
@@ -14,6 +14,7 @@ from beet.library.data_pack import Advancement
 
 AdvancementIcon = dict[str, Any]
 
+
 class ProjectAdvancementOptions(BaseModel):
     icon: AdvancementIcon = {"item": "minecraft:apple"}
     author_namespace: Optional[str]
@@ -22,78 +23,93 @@ class ProjectAdvancementOptions(BaseModel):
     project_namespace: Optional[str]
     project_advancement_path: Optional[str]
 
+
 def beet_default(ctx: Context):
     ctx.require(project_advancement)
+
 
 @configurable(validator=ProjectAdvancementOptions)
 def project_advancement(ctx: Context, opts: ProjectAdvancementOptions):
     author_namespace = opts.author_namespace or ctx.project_author.lower()
     project_namespace = opts.project_namespace or ctx.project_id
-    project_advancement_path = opts.project_advancement_path or f"{author_namespace}:{project_namespace}/installed"
+    project_advancement_path = (
+        opts.project_advancement_path
+        or f"{author_namespace}:{project_namespace}/installed"
+    )
     skull_owner = opts.author_skull_owner or ctx.project_author
 
     if not author_namespace:
-        raise ValueError("Missing author namespace. Either author or author_namespace need to be configured")
+        raise ValueError(
+            "Missing author namespace. Either author or author_namespace need to be configured"
+        )
 
     if not skull_owner:
-        raise ValueError("Missing skull owner. Either author or author_skull_owner need to be configured")
+        raise ValueError(
+            "Missing skull owner. Either author or author_skull_owner need to be configured"
+        )
 
     ctx.data["global:root"] = create_root_advancement()
-    ctx.data[f"global:{author_namespace}"] = create_author_advancment(ctx.project_author, opts.author_description, skull_owner)
-    ctx.data[project_advancement_path] = create_project_advancement(ctx.project_name, ctx.project_description, author_namespace, opts.icon)
+    ctx.data[f"global:{author_namespace}"] = create_author_advancment(
+        ctx.project_author, opts.author_description, skull_owner
+    )
+    ctx.data[project_advancement_path] = create_project_advancement(
+        ctx.project_name, ctx.project_description, author_namespace, opts.icon
+    )
+
 
 def create_root_advancement():
-    return Advancement({
-        "display": {
-            "title": "Installed Datapacks",
-            "description": "",
-            "icon": {
-                "item": "minecraft:knowledge_book"
+    return Advancement(
+        {
+            "display": {
+                "title": "Installed Datapacks",
+                "description": "",
+                "icon": {"item": "minecraft:knowledge_book"},
+                "background": "minecraft:textures/block/gray_concrete.png",
+                "show_toast": False,
+                "announce_to_chat": False,
             },
-            "background": "minecraft:textures/block/gray_concrete.png",
-            "show_toast": False,
-            "announce_to_chat": False
-        },
-        "criteria": {
-            "trigger": {
-                "trigger": "minecraft:tick"
-            }
+            "criteria": {"trigger": {"trigger": "minecraft:tick"}},
         }
-    })
+    )
 
-def create_author_advancment(author: TextComponent, author_description: TextComponent, skull_owner: str):
-    return Advancement({
-        "display": {
-            "title": author,
-            "description": author_description,
-            "icon": {
-                "item": "minecraft:player_head",
-                "nbt": f"{{'SkullOwner': '{skull_owner}'}}"
+
+def create_author_advancment(
+    author: TextComponent, author_description: TextComponent, skull_owner: str
+):
+    return Advancement(
+        {
+            "display": {
+                "title": author,
+                "description": author_description,
+                "icon": {
+                    "item": "minecraft:player_head",
+                    "nbt": f"{{'SkullOwner': '{skull_owner}'}}",
+                },
+                "show_toast": False,
+                "announce_to_chat": False,
             },
-            "show_toast": False,
-            "announce_to_chat": False
-        },
-        "parent": "global:root",
-        "criteria": {
-            "trigger": {
-                "trigger": "minecraft:tick"
-            }
+            "parent": "global:root",
+            "criteria": {"trigger": {"trigger": "minecraft:tick"}},
         }
-    })
+    )
 
-def create_project_advancement(project_name: TextComponent, project_description: TextComponent, author_namespace: str, icon: AdvancementIcon):
-    return Advancement({
-        "display": {
-            "title": project_name,
-            "description": project_description,
-            "icon": icon,
-            "announce_to_chat": False,
-            "show_toast": False
-        },
-        "parent": f"global:{author_namespace}",
-        "criteria": {
-            "trigger": {
-                "trigger": "minecraft:tick"
-            }
+
+def create_project_advancement(
+    project_name: TextComponent,
+    project_description: TextComponent,
+    author_namespace: str,
+    icon: AdvancementIcon,
+):
+    return Advancement(
+        {
+            "display": {
+                "title": project_name,
+                "description": project_description,
+                "icon": icon,
+                "announce_to_chat": False,
+                "show_toast": False,
+            },
+            "parent": f"global:{author_namespace}",
+            "criteria": {"trigger": {"trigger": "minecraft:tick"}},
         }
-    })
+    )

--- a/beet/contrib/project_advancement.py
+++ b/beet/contrib/project_advancement.py
@@ -1,0 +1,99 @@
+"""
+    Plugin that generates a advancement for this project.
+
+    The aim of a project advancement is to replace installation messages in an easily viewable and non-obstructive way by putting them on a single advancement page.
+"""
+
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+from beet import Context, configurable
+from beet.core.utils import TextComponent
+from beet.library.data_pack import Advancement
+
+AdvancementIcon = dict[str, Any]
+
+class ProjectAdvancementOptions(BaseModel):
+    icon: AdvancementIcon = {"item": "minecraft:apple"}
+    author_namespace: Optional[str]
+    author_description: str = ""
+    author_skull_owner: Optional[str]
+    project_namespace: Optional[str]
+    project_advancement_path: Optional[str]
+
+def beet_default(ctx: Context):
+    ctx.require(project_advancement)
+
+@configurable(validator=ProjectAdvancementOptions)
+def project_advancement(ctx: Context, opts: ProjectAdvancementOptions):
+    author_namespace = opts.author_namespace or ctx.project_author.lower()
+    project_namespace = opts.project_namespace or ctx.project_id
+    project_advancement_path = opts.project_advancement_path or f"{author_namespace}:{project_namespace}/installed"
+    skull_owner = opts.author_skull_owner or ctx.project_author
+
+    if not author_namespace:
+        raise ValueError("Missing author namespace. Either author or author_namespace need to be configured")
+
+    if not skull_owner:
+        raise ValueError("Missing skull owner. Either author or author_skull_owner need to be configured")
+
+    ctx.data["global:root"] = create_root_advancement()
+    ctx.data[f"global:{author_namespace}"] = create_author_advancment(ctx.project_author, opts.author_description, skull_owner)
+    ctx.data[project_advancement_path] = create_project_advancement(ctx.project_name, ctx.project_description, author_namespace, opts.icon)
+
+def create_root_advancement():
+    return Advancement({
+        "display": {
+            "title": "Installed Datapacks",
+            "description": "",
+            "icon": {
+                "item": "minecraft:knowledge_book"
+            },
+            "background": "minecraft:textures/block/gray_concrete.png",
+            "show_toast": False,
+            "announce_to_chat": False
+        },
+        "criteria": {
+            "trigger": {
+                "trigger": "minecraft:tick"
+            }
+        }
+    })
+
+def create_author_advancment(author: TextComponent, author_description: TextComponent, skull_owner: str):
+    return Advancement({
+        "display": {
+            "title": author,
+            "description": author_description,
+            "icon": {
+                "item": "minecraft:player_head",
+                "nbt": f"{{'SkullOwner': '{skull_owner}'}}"
+            },
+            "show_toast": False,
+            "announce_to_chat": False
+        },
+        "parent": "global:root",
+        "criteria": {
+            "trigger": {
+                "trigger": "minecraft:tick"
+            }
+        }
+    })
+
+def create_project_advancement(project_name: TextComponent, project_description: TextComponent, author_namespace: str, icon: AdvancementIcon):
+    return Advancement({
+        "display": {
+            "title": project_name,
+            "description": project_description,
+            "icon": icon,
+            "announce_to_chat": False,
+            "show_toast": False
+        },
+        "parent": f"global:{author_namespace}",
+        "criteria": {
+            "trigger": {
+                "trigger": "minecraft:tick"
+            }
+        }
+    })

--- a/examples/project_advancement/beet.json
+++ b/examples/project_advancement/beet.json
@@ -1,0 +1,17 @@
+{
+	"author": "mcbeet",
+	"name": "Example",
+	"description": "An example project",
+	"pipeline": [
+		"beet.contrib.project_advancement"
+	],
+	"meta": {
+		"project_advancement": {
+			"icon": {
+				"item": "minecraft:red_mushroom",
+				"nbt": "{Enchantments:[{}]}"
+			},
+			"author_description": "Organization behind the beet project"
+		}
+	}
+}

--- a/tests/snapshots/examples__build_project_advancement__0.data_pack/data/global/advancements/mcbeet.json
+++ b/tests/snapshots/examples__build_project_advancement__0.data_pack/data/global/advancements/mcbeet.json
@@ -1,0 +1,18 @@
+{
+  "display": {
+    "title": "mcbeet",
+    "description": "Organization behind the beet project",
+    "icon": {
+      "item": "minecraft:player_head",
+      "nbt": "{'SkullOwner': 'mcbeet'}"
+    },
+    "show_toast": false,
+    "announce_to_chat": false
+  },
+  "parent": "global:root",
+  "criteria": {
+    "trigger": {
+      "trigger": "minecraft:tick"
+    }
+  }
+}

--- a/tests/snapshots/examples__build_project_advancement__0.data_pack/data/global/advancements/root.json
+++ b/tests/snapshots/examples__build_project_advancement__0.data_pack/data/global/advancements/root.json
@@ -1,0 +1,17 @@
+{
+  "display": {
+    "title": "Installed Datapacks",
+    "description": "",
+    "icon": {
+      "item": "minecraft:knowledge_book"
+    },
+    "background": "minecraft:textures/block/gray_concrete.png",
+    "show_toast": false,
+    "announce_to_chat": false
+  },
+  "criteria": {
+    "trigger": {
+      "trigger": "minecraft:tick"
+    }
+  }
+}

--- a/tests/snapshots/examples__build_project_advancement__0.data_pack/data/mcbeet/advancements/example/installed.json
+++ b/tests/snapshots/examples__build_project_advancement__0.data_pack/data/mcbeet/advancements/example/installed.json
@@ -1,0 +1,18 @@
+{
+  "display": {
+    "title": "Example",
+    "description": "An example project",
+    "icon": {
+      "item": "minecraft:red_mushroom",
+      "nbt": "{Enchantments:[{}]}"
+    },
+    "announce_to_chat": false,
+    "show_toast": false
+  },
+  "parent": "global:mcbeet",
+  "criteria": {
+    "trigger": {
+      "trigger": "minecraft:tick"
+    }
+  }
+}

--- a/tests/snapshots/examples__build_project_advancement__0.data_pack/pack.mcmeta
+++ b/tests/snapshots/examples__build_project_advancement__0.data_pack/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 7,
+    "description": "An example project\nAuthor: mcbeet"
+  }
+}

--- a/tests/snapshots/examples__build_project_advancement__1.resource_pack/pack.mcmeta
+++ b/tests/snapshots/examples__build_project_advancement__1.resource_pack/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 7,
+    "description": "An example project\nAuthor: mcbeet"
+  }
+}


### PR DESCRIPTION
Implements the datapack advancement plugin discussed in #99. Renamed to "Project Advancement" to make the use of the plugin easier to understand.

Includes:
- Basic features discussed in #99
- Configuration via @configurable decorator
- Additional settings `author_description`, `project_namespace` and `project_advancement_path`
- Test snapshots for basic configuration example