### PR TITLE
Fix `yellow_shulker_box` for 1.18

### DIFF
--- a/beet/contrib/yellow_shulker_box.py
+++ b/beet/contrib/yellow_shulker_box.py
@@ -50,6 +50,7 @@ def beet_default(ctx: Context):
                 },
                 {
                     "function": "minecraft:set_contents",
+                    "type": "minecraft:shulker_box",
                     "entries": [
                         {
                             "type": "minecraft:dynamic",


### PR DESCRIPTION
Adds the `type` field to `set_contents` function, which is a breaking change in 1.18. It's also compatible with 1.17 since unknown fields are ignored.