### PR TITLE
feat: add beet.contrib.optifine

### DIFF
--- a/beet/contrib/optifine.py
+++ b/beet/contrib/optifine.py
@@ -13,7 +13,7 @@ __all__ = [
 
 from typing import Union
 
-from beet import Context, JsonFile, ResourcePack, TextFile, Texture
+from beet import Context, JsonFile, PngFile, ResourcePack, TextFile
 
 
 def beet_default(ctx: Context):
@@ -54,10 +54,11 @@ class OptifineProperties(TextFile):
     extension = ".properties"
 
 
-class OptifineTexture(Texture):
+class OptifineTexture(PngFile):
     """Class representing an optifine texture."""
 
     scope = ("optifine",)
+    extension = ".png"
 
 
 class ShaderProperties(TextFile):

--- a/beet/contrib/optifine.py
+++ b/beet/contrib/optifine.py
@@ -1,0 +1,67 @@
+"""Plugin for supporting optifine resources."""
+
+
+__all__ = [
+    "optifine",
+    "JsonEntityModel",
+    "JsonPartModel",
+    "OptifineProperties",
+    "ShaderProperties",
+    "OptifineTexture",
+]
+
+
+from typing import Union
+
+from beet import Context, JsonFile, ResourcePack, TextFile, Texture
+
+
+def beet_default(ctx: Context):
+    ctx.require(optifine)
+
+
+def optifine(pack: Union[Context, ResourcePack]):
+    """Enable optifine resources."""
+    if isinstance(pack, Context):
+        pack = pack.assets
+    pack.extend_namespace += [
+        JsonEntityModel,
+        JsonPartModel,
+        OptifineProperties,
+        ShaderProperties,
+        OptifineTexture,
+    ]
+
+
+class JsonEntityModel(JsonFile):
+    """Class representing a json entity model."""
+
+    scope = ("optifine", "cem")
+    extension = ".jem"
+
+
+class JsonPartModel(JsonFile):
+    """Class representing a json part model."""
+
+    scope = ("optifine", "cem")
+    extension = ".jpm"
+
+
+class OptifineProperties(TextFile):
+    """Class representing optifine properties."""
+
+    scope = ("optifine",)
+    extension = ".properties"
+
+
+class OptifineTexture(Texture):
+    """Class representing an optifine texture."""
+
+    scope = ("optifine",)
+
+
+class ShaderProperties(TextFile):
+    """Class representing shader properties."""
+
+    scope = ("shaders",)
+    extension = ".properties"


### PR DESCRIPTION
A plugin that registers Optifine custom resources to resource packs such as `.properties`, `.jem` and `.jpm` files. Hopefully, it's not missing anything, but i'm not very familiar with Optifine :).

Optifine documentation: [https://optifine.readthedocs.io/](https://optifine.readthedocs.io/)