### PR TITLE
Atlas Feature

### DIFF
--- a/beet/library/resource_pack.py
+++ b/beet/library/resource_pack.py
@@ -334,6 +334,7 @@ class ResourcePackNamespace(Namespace):
     textures:         NamespacePin[Texture]        = NamespacePin(Texture)
     sounds:           NamespacePin[Sound]          = NamespacePin(Sound)
     particles:        NamespacePin[Particle]       = NamespacePin(Particle)
+    atlases:          NamespacePin[Atlas]          = NamespacePin(Atlas)
     # fmt: on
 
     @classmethod
@@ -383,4 +384,5 @@ class ResourcePack(Pack[ResourcePackNamespace]):
     textures:         NamespaceProxyDescriptor[Texture]        = NamespaceProxyDescriptor(Texture)
     sounds:           NamespaceProxyDescriptor[Sound]          = NamespaceProxyDescriptor(Sound)
     particles:        NamespaceProxyDescriptor[Particle]       = NamespaceProxyDescriptor(Particle)
+    atlases:          NamespaceProxyDescriptor[Atlas]          = NamespaceProxyDescriptor(Atlas)
     # fmt: on

--- a/beet/library/resource_pack.py
+++ b/beet/library/resource_pack.py
@@ -21,10 +21,10 @@ __all__ = [
 ]
 
 
+from contextlib import suppress
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, ClassVar, Dict, Optional, Tuple, Type
-from contextlib import suppress
 
 try:
     from PIL.Image import Image
@@ -274,7 +274,7 @@ class Atlas(JsonFile):
             if value not in values:
                 values.append(deepcopy(value))
         return True
-    
+
     def append(self, other: "Atlas"):
         """Append values from another atlas."""
 

--- a/beet/library/resource_pack.py
+++ b/beet/library/resource_pack.py
@@ -1,4 +1,5 @@
 __all__ = [
+    "Atlas",
     "ResourcePack",
     "ResourcePackNamespace",
     "Blockstate",
@@ -277,12 +278,10 @@ class Atlas(JsonFile):
 
     def append(self, other: "Atlas"):
         """Append values from another atlas."""
-
         self.merge(other)
 
     def prepend(self, other: "Atlas"):
         """Prepend values from another atlas."""
-
         values = self.data.setdefault("sources", [])
 
         for value in other.data.get("sources", []):
@@ -291,14 +290,12 @@ class Atlas(JsonFile):
 
     def add(self, value: JsonDict):
         """Add an entry."""
-
         values = self.data.setdefault("sources", [])
         if value not in values:
             values.append(value)
 
     def remove(self, value: JsonDict):
         """Remove an entry."""
-
         values = self.data.setdefault("sources", [])
         with suppress(ValueError):
             values.remove(value)

--- a/beet/library/resource_pack.py
+++ b/beet/library/resource_pack.py
@@ -24,6 +24,7 @@ __all__ = [
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, ClassVar, Dict, Optional, Tuple, Type
+from contextlib import suppress
 
 try:
     from PIL.Image import Image
@@ -258,6 +259,53 @@ class Particle(JsonFile):
 
     scope: ClassVar[Tuple[str, ...]] = ("particles",)
     extension: ClassVar[str] = ".json"
+
+
+class Atlas(JsonFile):
+    """Class representing an atlas configuration file."""
+
+    scope: ClassVar[Tuple[str, ...]] = ("atlases",)
+    extension: ClassVar[str] = ".json"
+
+    def merge(self, other: "Atlas") -> bool:  # type: ignore
+        values = self.data.setdefault("sources", [])
+
+        for value in other.data.get("sources", []):
+            if value not in values:
+                values.append(deepcopy(value))
+        return True
+    
+    def append(self, other: "Atlas"):
+        """Append values from another atlas."""
+
+        self.merge(other)
+
+    def prepend(self, other: "Atlas"):
+        """Prepend values from another atlas."""
+
+        values = self.data.setdefault("sources", [])
+
+        for value in other.data.get("sources", []):
+            if value not in values:
+                values.insert(0, deepcopy(value))
+
+    def add(self, value: str):
+        """Add an entry."""
+
+        values = self.data.setdefault("sources", [])
+        if value not in values:
+            values.append(value)
+
+    def remove(self, value: str):
+        """Remove an entry."""
+
+        values = self.data.setdefault("sources", [])
+        with suppress(ValueError):
+            values.remove(value)
+
+    @classmethod
+    def default(cls) -> JsonDict:
+        return {"sources": []}
 
 
 class ResourcePackNamespace(Namespace):

--- a/beet/library/resource_pack.py
+++ b/beet/library/resource_pack.py
@@ -289,14 +289,14 @@ class Atlas(JsonFile):
             if value not in values:
                 values.insert(0, deepcopy(value))
 
-    def add(self, value: str):
+    def add(self, value: JsonDict):
         """Add an entry."""
 
         values = self.data.setdefault("sources", [])
         if value not in values:
             values.append(value)
 
-    def remove(self, value: str):
+    def remove(self, value: JsonDict):
         """Remove an entry."""
 
         values = self.data.setdefault("sources", [])

--- a/examples/load_atlases/atlas1.json
+++ b/examples/load_atlases/atlas1.json
@@ -1,0 +1,9 @@
+{
+  "sources": [
+    {
+      "type": "directory",
+      "source": "assembly",
+      "prefix": "assembly/"
+    }
+  ]
+}

--- a/examples/load_atlases/atlas2.json
+++ b/examples/load_atlases/atlas2.json
@@ -1,0 +1,9 @@
+{
+  "sources": [
+    {
+      "type": "directory",
+      "source": "base",
+      "prefix": "base/"
+    }
+  ]
+}

--- a/examples/load_atlases/atlas3.json
+++ b/examples/load_atlases/atlas3.json
@@ -1,0 +1,9 @@
+{
+  "sources": [
+    {
+      "type": "directory",
+      "source": "test",
+      "prefix": "test/"
+    }
+  ]
+}

--- a/examples/load_atlases/beet.yml
+++ b/examples/load_atlases/beet.yml
@@ -1,0 +1,5 @@
+resource_pack:
+  load:
+    - assets/minecraft/atlases/blocks.json: atlas1.json
+    - assets/minecraft/atlases/blocks.json: atlas2.json
+    - assets/minecraft/atlases/blocks.json: atlas3.json

--- a/tests/snapshots/examples__build_load_atlases__0.data_pack/pack.mcmeta
+++ b/tests/snapshots/examples__build_load_atlases__0.data_pack/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 10,
+    "description": ""
+  }
+}

--- a/tests/snapshots/examples__build_load_atlases__1.resource_pack/assets/minecraft/atlases/blocks.json
+++ b/tests/snapshots/examples__build_load_atlases__1.resource_pack/assets/minecraft/atlases/blocks.json
@@ -1,0 +1,19 @@
+{
+  "sources": [
+    {
+      "type": "directory",
+      "source": "assembly",
+      "prefix": "assembly/"
+    },
+    {
+      "type": "directory",
+      "source": "base",
+      "prefix": "base/"
+    },
+    {
+      "type": "directory",
+      "source": "test",
+      "prefix": "test/"
+    }
+  ]
+}

--- a/tests/snapshots/examples__build_load_atlases__1.resource_pack/pack.mcmeta
+++ b/tests/snapshots/examples__build_load_atlases__1.resource_pack/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 9,
+    "description": ""
+  }
+}


### PR DESCRIPTION
In Minecraft 1.19.3, the `atlases` resource location was added to `assets` ([wiki](https://minecraft.fandom.com/wiki/Java_Edition_1.19.3#General_2)).

This PR adds an `Atlas` object to the `ResourcePack` namespace alongside the merging behavior which is modeled directly from the `tag` behavior (minus the `replace` feature).

There is also a test case which loads 3 atlases and merges them.