### PR TITLE
feat: add `damage_type` resource

### DIFF
--- a/beet/library/data_pack.py
+++ b/beet/library/data_pack.py
@@ -54,6 +54,13 @@ class Advancement(JsonFile):
     extension: ClassVar[str] = ".json"
 
 
+class DamageType(JsonFile):
+    """Class representing a damage type."""
+
+    scope: ClassVar[Tuple[str, ...]] = ("damage_type",)
+    extension: ClassVar[str] = ".json"
+
+
 @dataclass(eq=False, repr=False)
 class Function(TextFileBase[List[str]]):
     """Class representing a function."""

--- a/beet/library/data_pack.py
+++ b/beet/library/data_pack.py
@@ -2,6 +2,7 @@ __all__ = [
     "DataPack",
     "DataPackNamespace",
     "Advancement",
+    "DamageType",
     "Function",
     "ItemModifier",
     "LootTable",
@@ -262,6 +263,7 @@ class DataPackNamespace(Namespace):
 
     # fmt: off
     advancements:     NamespacePin[Advancement]   = NamespacePin(Advancement)
+    damage_type:      NamespacePin[DamageType]    = NamespacePin(DamageType)
     functions:        NamespacePin[Function]      = NamespacePin(Function)
     loot_tables:      NamespacePin[LootTable]     = NamespacePin(LootTable)
     predicates:       NamespacePin[Predicate]     = NamespacePin(Predicate)
@@ -295,6 +297,7 @@ class DataPack(Pack[DataPackNamespace]):
 
     # fmt: off
     advancements:     NamespaceProxyDescriptor[Advancement]   = NamespaceProxyDescriptor(Advancement)
+    damage_type:      NamespaceProxyDescriptor[DamageType]    = NamespaceProxyDescriptor(DamageType)
     functions:        NamespaceProxyDescriptor[Function]      = NamespaceProxyDescriptor(Function)
     loot_tables:      NamespaceProxyDescriptor[LootTable]     = NamespaceProxyDescriptor(LootTable)
     predicates:       NamespaceProxyDescriptor[Predicate]     = NamespaceProxyDescriptor(Predicate)

--- a/examples/load_damage_type/beet.yml
+++ b/examples/load_damage_type/beet.yml
@@ -1,0 +1,2 @@
+data_pack:
+  load: [src]

--- a/examples/load_damage_type/src/data/demo/damage_type/boomerang.json
+++ b/examples/load_damage_type/src/data/demo/damage_type/boomerang.json
@@ -1,0 +1,5 @@
+{
+  "exhaustion": 0.1,
+  "message_id": "tcc.boomerang",
+  "scaling": "never"
+}

--- a/examples/load_damage_type/src/data/demo/damage_type/swordfish.json
+++ b/examples/load_damage_type/src/data/demo/damage_type/swordfish.json
@@ -1,0 +1,5 @@
+{
+  "exhaustion": 0.0,
+  "message_id": "tcc.swordfish",
+  "scaling": "never"
+}

--- a/tests/snapshots/examples__build_load_damage_type__0.data_pack/data/demo/damage_type/boomerang.json
+++ b/tests/snapshots/examples__build_load_damage_type__0.data_pack/data/demo/damage_type/boomerang.json
@@ -1,0 +1,5 @@
+{
+  "exhaustion": 0.1,
+  "message_id": "tcc.boomerang",
+  "scaling": "never"
+}

--- a/tests/snapshots/examples__build_load_damage_type__0.data_pack/data/demo/damage_type/swordfish.json
+++ b/tests/snapshots/examples__build_load_damage_type__0.data_pack/data/demo/damage_type/swordfish.json
@@ -1,0 +1,5 @@
+{
+  "exhaustion": 0.0,
+  "message_id": "tcc.swordfish",
+  "scaling": "never"
+}

--- a/tests/snapshots/examples__build_load_damage_type__0.data_pack/pack.mcmeta
+++ b/tests/snapshots/examples__build_load_damage_type__0.data_pack/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 10,
+    "description": ""
+  }
+}

--- a/tests/snapshots/examples__build_load_damage_type__1.resource_pack/pack.mcmeta
+++ b/tests/snapshots/examples__build_load_damage_type__1.resource_pack/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 9,
+    "description": ""
+  }
+}


### PR DESCRIPTION
From 1.19.4. Also, could consider adding a test for all resources in a `load_resources` example as a separate PR.