### PR TITLE
feat: dynamic 1.21 support

### DIFF
--- a/beet/contrib/optifine.py
+++ b/beet/contrib/optifine.py
@@ -35,33 +35,33 @@ def optifine(pack: Union[Context, ResourcePack]):
 class JsonEntityModel(JsonFile):
     """Class representing a json entity model."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("optifine", "cem")
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("optifine", "cem"),)
     extension: ClassVar[str] = ".jem"
 
 
 class JsonPartModel(JsonFile):
     """Class representing a json part model."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("optifine", "cem")
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("optifine", "cem"),)
     extension: ClassVar[str] = ".jpm"
 
 
 class OptifineProperties(TextFile):
     """Class representing optifine properties."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("optifine",)
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("optifine",),)
     extension: ClassVar[str] = ".properties"
 
 
 class OptifineTexture(PngFile):
     """Class representing an optifine texture."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("optifine",)
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("optifine",),)
     extension: ClassVar[str] = ".png"
 
 
 class ShaderProperties(TextFile):
     """Class representing shader properties."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("shaders",)
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("shaders",),)
     extension: ClassVar[str] = ".properties"

--- a/beet/core/file.py
+++ b/beet/core/file.py
@@ -480,7 +480,6 @@ class TextFileBase(File[ValueType, str]):
             return super().convert(file_type)
         return file_type(self.text)
 
-
 class TextFile(TextFileBase[str]):
     """Class representing a text file."""
 

--- a/beet/library/base.py
+++ b/beet/library/base.py
@@ -102,7 +102,7 @@ PACK_COMPRESSION: Dict[str, int] = {
 class NamespaceFile(Protocol):
     """Protocol for detecting files that belong in pack namespaces."""
 
-    scope: ClassVar[list[Tuple[str, ...]]]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]]
     extension: ClassVar[str]
 
     snake_name: ClassVar[str]
@@ -150,6 +150,7 @@ class NamespaceFile(Protocol):
     def dump(self, origin: FileOrigin, path: FileSystemPath): ...
 
     def convert(self, file_type: Type[PackFileType]) -> PackFileType: ...
+
 
 class MergeCallback(Protocol):
     """Protocol for detecting merge callbacks."""

--- a/beet/library/data_pack.py
+++ b/beet/library/data_pack.py
@@ -57,36 +57,41 @@ TagFileType = TypeVar("TagFileType", bound="TagFile")
 class Advancement(JsonFile):
     """Class representing an advancement."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("advancement",), ("advancements",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("advancement",), ("advancements",),)
     extension: ClassVar[str] = ".json"
 
 
 class DamageType(JsonFile):
     """Class representing a damage type."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("damage_type",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("damage_type",),)
     extension: ClassVar[str] = ".json"
 
 
 class ChatType(JsonFile):
     """Class representing a chat type."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("chat_type",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("chat_type",),)
     extension: ClassVar[str] = ".json"
 
 
 class BannerPattern(JsonFile):
     """Class representing a banner pattern."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("banner_pattern",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("banner_pattern",),)
     extension: ClassVar[str] = ".json"
 
 
 class WolfVariant(JsonFile):
     """Class representing a wolf variant."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("wolf_variant",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("wolf_variant",),)
     extension: ClassVar[str] = ".json"
+
+class Enchantment(JsonFile):
+    """Class representing an enchantment"""
+
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("enchantment",),)
 
 
 @dataclass(eq=False, repr=False)
@@ -97,7 +102,7 @@ class Function(TextFileBase[List[str]]):
     tags: Optional[List[str]] = extra_field(default=None)
     prepend_tags: Optional[List[str]] = extra_field(default=None)
 
-    scope: ClassVar[List[Tuple[str, ...]]] = [("function",), ("functions",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("function",), ("functions",))
     extension: ClassVar[str] = ".mcfunction"
 
     lines: ClassVar[FileDeserialize[List[str]]] = FileDeserialize()
@@ -144,28 +149,28 @@ class Function(TextFileBase[List[str]]):
 class ItemModifier(JsonFile):
     """Class representing an item modifier."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("item_modifier",), ("item_modifiers",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("item_modifier",), ("item_modifiers",),)
     extension: ClassVar[str] = ".json"
 
 
 class LootTable(JsonFile):
     """Class representing a loot table."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("loot_table",), ("loot_tables",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("loot_table",), ("loot_tables",),)
     extension: ClassVar[str] = ".json"
 
 
 class Predicate(JsonFile):
     """Class representing a predicate."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("predicate",), ("predicates",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("predicate",), ("predicates",),)
     extension: ClassVar[str] = ".json"
 
 
 class Recipe(JsonFile):
     """Class representing a recipe."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("recipe",), ("recipes",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("recipe",), ("recipes",),)
     extension: ClassVar[str] = ".json"
 
 
@@ -175,7 +180,7 @@ class Structure(BinaryFileBase[StructureFileData]):
 
     content: BinaryFileContent[StructureFileData] = None
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("structure",), ("structures",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("structure",), ("structures",),)
     extension: ClassVar[str] = ".nbt"
 
     data: ClassVar[FileDeserialize[StructureFileData]] = FileDeserialize()
@@ -194,14 +199,14 @@ class Structure(BinaryFileBase[StructureFileData]):
 class TrimPattern(JsonFile):
     """Class representing a trim pattern."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("trim_pattern",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("trim_pattern",),)
     extension: ClassVar[str] = ".json"
 
 
 class TrimMaterial(JsonFile):
     """Class representing a trim material."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("trim_material",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("trim_material",),)
     extension: ClassVar[str] = ".json"
 
 
@@ -262,53 +267,52 @@ class TagFile(JsonFile):
 class BlockTag(TagFile):
     """Class representing a block tag."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("tags", "blocks")]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("tags", "blocks"), ("tags", "block"),)
 
 
 class EntityTypeTag(TagFile):
     """Class representing an entity tag."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("tags", "entity_types")]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("tags", "entity_types"), ("tags", "entity_type"),)
 
 
 class FluidTag(TagFile):
     """Class representing a fluid tag."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("tags", "fluids")]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("tags", "fluids"), ("tags", "fluid"),)
 
 
 class FunctionTag(TagFile):
     """Class representing a function tag."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (
         ("tags", "function"),
         ("tags", "functions"),
-    ]
+    )
 
 
 class GameEventTag(TagFile):
     """Class representing a game event tag."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("tags", "game_events")]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("tags", "game_events"), ("tags", "game_event"),)
 
 
 class ItemTag(TagFile):
     """Class representing an item tag."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("tags", "items")]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("tags", "items"), ("tags", "item"),)
 
 
 class ChatTypeTag(TagFile):
     """Class representing a chat type tag."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("tags", "chat_type")]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("tags", "chat_type"),)
 
 
 class DamageTypeTag(TagFile):
     """Class representing a damage type tag."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("tags", "damage_type")]
-
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("tags", "damage_type"),)
 
 class DataPackNamespace(Namespace):
     """Class representing a data pack namespace."""

--- a/beet/library/data_pack.py
+++ b/beet/library/data_pack.py
@@ -6,6 +6,7 @@ __all__ = [
     "ChatType",
     "BannerPattern",
     "WolfVariant",
+    "Enchantment",
     "Function",
     "ItemModifier",
     "LootTable",
@@ -57,7 +58,10 @@ TagFileType = TypeVar("TagFileType", bound="TagFile")
 class Advancement(JsonFile):
     """Class representing an advancement."""
 
-    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("advancement",), ("advancements",),)
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (
+        ("advancement",),
+        ("advancements",),
+    )
     extension: ClassVar[str] = ".json"
 
 
@@ -88,10 +92,12 @@ class WolfVariant(JsonFile):
     scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("wolf_variant",),)
     extension: ClassVar[str] = ".json"
 
+
 class Enchantment(JsonFile):
     """Class representing an enchantment"""
 
     scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("enchantment",),)
+    extension: ClassVar[str] = ".json"
 
 
 @dataclass(eq=False, repr=False)
@@ -149,28 +155,40 @@ class Function(TextFileBase[List[str]]):
 class ItemModifier(JsonFile):
     """Class representing an item modifier."""
 
-    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("item_modifier",), ("item_modifiers",),)
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (
+        ("item_modifier",),
+        ("item_modifiers",),
+    )
     extension: ClassVar[str] = ".json"
 
 
 class LootTable(JsonFile):
     """Class representing a loot table."""
 
-    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("loot_table",), ("loot_tables",),)
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (
+        ("loot_table",),
+        ("loot_tables",),
+    )
     extension: ClassVar[str] = ".json"
 
 
 class Predicate(JsonFile):
     """Class representing a predicate."""
 
-    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("predicate",), ("predicates",),)
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (
+        ("predicate",),
+        ("predicates",),
+    )
     extension: ClassVar[str] = ".json"
 
 
 class Recipe(JsonFile):
     """Class representing a recipe."""
 
-    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("recipe",), ("recipes",),)
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (
+        ("recipe",),
+        ("recipes",),
+    )
     extension: ClassVar[str] = ".json"
 
 
@@ -180,7 +198,10 @@ class Structure(BinaryFileBase[StructureFileData]):
 
     content: BinaryFileContent[StructureFileData] = None
 
-    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("structure",), ("structures",),)
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (
+        ("structure",),
+        ("structures",),
+    )
     extension: ClassVar[str] = ".nbt"
 
     data: ClassVar[FileDeserialize[StructureFileData]] = FileDeserialize()
@@ -267,19 +288,28 @@ class TagFile(JsonFile):
 class BlockTag(TagFile):
     """Class representing a block tag."""
 
-    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("tags", "blocks"), ("tags", "block"),)
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (
+        ("tags", "blocks"),
+        ("tags", "block"),
+    )
 
 
 class EntityTypeTag(TagFile):
     """Class representing an entity tag."""
 
-    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("tags", "entity_types"), ("tags", "entity_type"),)
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (
+        ("tags", "entity_types"),
+        ("tags", "entity_type"),
+    )
 
 
 class FluidTag(TagFile):
     """Class representing a fluid tag."""
 
-    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("tags", "fluids"), ("tags", "fluid"),)
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (
+        ("tags", "fluids"),
+        ("tags", "fluid"),
+    )
 
 
 class FunctionTag(TagFile):
@@ -294,13 +324,19 @@ class FunctionTag(TagFile):
 class GameEventTag(TagFile):
     """Class representing a game event tag."""
 
-    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("tags", "game_events"), ("tags", "game_event"),)
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (
+        ("tags", "game_events"),
+        ("tags", "game_event"),
+    )
 
 
 class ItemTag(TagFile):
     """Class representing an item tag."""
 
-    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("tags", "items"), ("tags", "item"),)
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (
+        ("tags", "items"),
+        ("tags", "item"),
+    )
 
 
 class ChatTypeTag(TagFile):
@@ -313,6 +349,7 @@ class DamageTypeTag(TagFile):
     """Class representing a damage type tag."""
 
     scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("tags", "damage_type"),)
+
 
 class DataPackNamespace(Namespace):
     """Class representing a data pack namespace."""
@@ -333,6 +370,7 @@ class DataPackNamespace(Namespace):
     damage_type:      NamespacePin[DamageType]    = NamespacePin(DamageType)
     banner_patterns:  NamespacePin[BannerPattern] = NamespacePin(BannerPattern)
     wolf_variants:    NamespacePin[WolfVariant]   = NamespacePin(WolfVariant)
+    enchantments:     NamespacePin[Enchantment]   = NamespacePin(Enchantment)
     block_tags:       NamespacePin[BlockTag]      = NamespacePin(BlockTag)
     entity_type_tags: NamespacePin[EntityTypeTag] = NamespacePin(EntityTypeTag)
     fluid_tags:       NamespacePin[FluidTag]      = NamespacePin(FluidTag)
@@ -341,6 +379,7 @@ class DataPackNamespace(Namespace):
     item_tags:        NamespacePin[ItemTag]       = NamespacePin(ItemTag)
     chat_type_tags:   NamespacePin[ChatTypeTag]   = NamespacePin(ChatTypeTag)
     damage_type_tags: NamespacePin[DamageTypeTag] = NamespacePin(DamageTypeTag)
+
     # fmt: on
 
     def get_output_scope(self, content_type: type[NamespaceFile]) -> Tuple[str, ...]:
@@ -381,6 +420,7 @@ class DataPack(Pack[DataPackNamespace]):
     damage_type:      NamespaceProxyDescriptor[DamageType]    = NamespaceProxyDescriptor(DamageType)
     banner_patterns:  NamespaceProxyDescriptor[BannerPattern] = NamespaceProxyDescriptor(BannerPattern)
     wolf_variants:    NamespaceProxyDescriptor[WolfVariant]   = NamespaceProxyDescriptor(WolfVariant)
+    enchantments:     NamespaceProxyDescriptor[Enchantment]   = NamespaceProxyDescriptor(Enchantment)
     block_tags:       NamespaceProxyDescriptor[BlockTag]      = NamespaceProxyDescriptor(BlockTag)
     entity_type_tags: NamespaceProxyDescriptor[EntityTypeTag] = NamespaceProxyDescriptor(EntityTypeTag)
     fluid_tags:       NamespaceProxyDescriptor[FluidTag]      = NamespaceProxyDescriptor(FluidTag)

--- a/beet/library/data_pack.py
+++ b/beet/library/data_pack.py
@@ -45,6 +45,7 @@ from beet.core.utils import JsonDict, extra_field, split_version
 from .base import (
     LATEST_MINECRAFT_VERSION,
     Namespace,
+    NamespaceFile,
     NamespacePin,
     NamespaceProxyDescriptor,
     Pack,
@@ -56,35 +57,35 @@ TagFileType = TypeVar("TagFileType", bound="TagFile")
 class Advancement(JsonFile):
     """Class representing an advancement."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("advancements",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("advancement",), ("advancements",)]
     extension: ClassVar[str] = ".json"
 
 
 class DamageType(JsonFile):
     """Class representing a damage type."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("damage_type",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("damage_type",)]
     extension: ClassVar[str] = ".json"
 
 
 class ChatType(JsonFile):
     """Class representing a chat type."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("chat_type",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("chat_type",)]
     extension: ClassVar[str] = ".json"
 
 
 class BannerPattern(JsonFile):
     """Class representing a banner pattern."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("banner_pattern",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("banner_pattern",)]
     extension: ClassVar[str] = ".json"
 
 
 class WolfVariant(JsonFile):
     """Class representing a wolf variant."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("wolf_variant",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("wolf_variant",)]
     extension: ClassVar[str] = ".json"
 
 
@@ -96,7 +97,7 @@ class Function(TextFileBase[List[str]]):
     tags: Optional[List[str]] = extra_field(default=None)
     prepend_tags: Optional[List[str]] = extra_field(default=None)
 
-    scope: ClassVar[Tuple[str, ...]] = ("functions",)
+    scope: ClassVar[List[Tuple[str, ...]]] = [("function",), ("functions",)]
     extension: ClassVar[str] = ".mcfunction"
 
     lines: ClassVar[FileDeserialize[List[str]]] = FileDeserialize()
@@ -143,28 +144,28 @@ class Function(TextFileBase[List[str]]):
 class ItemModifier(JsonFile):
     """Class representing an item modifier."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("item_modifiers",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("item_modifier",), ("item_modifiers",)]
     extension: ClassVar[str] = ".json"
 
 
 class LootTable(JsonFile):
     """Class representing a loot table."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("loot_tables",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("loot_table",), ("loot_tables",)]
     extension: ClassVar[str] = ".json"
 
 
 class Predicate(JsonFile):
     """Class representing a predicate."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("predicates",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("predicate",), ("predicates",)]
     extension: ClassVar[str] = ".json"
 
 
 class Recipe(JsonFile):
     """Class representing a recipe."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("recipes",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("recipe",), ("recipes",)]
     extension: ClassVar[str] = ".json"
 
 
@@ -174,7 +175,7 @@ class Structure(BinaryFileBase[StructureFileData]):
 
     content: BinaryFileContent[StructureFileData] = None
 
-    scope: ClassVar[Tuple[str, ...]] = ("structures",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("structure",), ("structures",)]
     extension: ClassVar[str] = ".nbt"
 
     data: ClassVar[FileDeserialize[StructureFileData]] = FileDeserialize()
@@ -193,14 +194,14 @@ class Structure(BinaryFileBase[StructureFileData]):
 class TrimPattern(JsonFile):
     """Class representing a trim pattern."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("trim_pattern",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("trim_pattern",)]
     extension: ClassVar[str] = ".json"
 
 
 class TrimMaterial(JsonFile):
     """Class representing a trim material."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("trim_material",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("trim_material",)]
     extension: ClassVar[str] = ".json"
 
 
@@ -261,49 +262,52 @@ class TagFile(JsonFile):
 class BlockTag(TagFile):
     """Class representing a block tag."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("tags", "blocks")
+    scope: ClassVar[list[Tuple[str, ...]]] = [("tags", "blocks")]
 
 
 class EntityTypeTag(TagFile):
     """Class representing an entity tag."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("tags", "entity_types")
+    scope: ClassVar[list[Tuple[str, ...]]] = [("tags", "entity_types")]
 
 
 class FluidTag(TagFile):
     """Class representing a fluid tag."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("tags", "fluids")
+    scope: ClassVar[list[Tuple[str, ...]]] = [("tags", "fluids")]
 
 
 class FunctionTag(TagFile):
     """Class representing a function tag."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("tags", "functions")
+    scope: ClassVar[list[Tuple[str, ...]]] = [
+        ("tags", "function"),
+        ("tags", "functions"),
+    ]
 
 
 class GameEventTag(TagFile):
     """Class representing a game event tag."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("tags", "game_events")
+    scope: ClassVar[list[Tuple[str, ...]]] = [("tags", "game_events")]
 
 
 class ItemTag(TagFile):
     """Class representing an item tag."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("tags", "items")
+    scope: ClassVar[list[Tuple[str, ...]]] = [("tags", "items")]
 
 
 class ChatTypeTag(TagFile):
     """Class representing a chat type tag."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("tags", "chat_type")
+    scope: ClassVar[list[Tuple[str, ...]]] = [("tags", "chat_type")]
 
 
 class DamageTypeTag(TagFile):
     """Class representing a damage type tag."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("tags", "damage_type")
+    scope: ClassVar[list[Tuple[str, ...]]] = [("tags", "damage_type")]
 
 
 class DataPackNamespace(Namespace):
@@ -335,6 +339,11 @@ class DataPackNamespace(Namespace):
     damage_type_tags: NamespacePin[DamageTypeTag] = NamespacePin(DamageTypeTag)
     # fmt: on
 
+    def get_output_scope(self, content_type: type[NamespaceFile]) -> Tuple[str, ...]:
+        if not self.pack or self.pack.pack_format >= 45:
+            return content_type.scope[0]
+        return content_type.scope[-1]
+
 
 class DataPack(Pack[DataPackNamespace]):
     """Class representing a data pack."""
@@ -350,6 +359,7 @@ class DataPack(Pack[DataPackNamespace]):
         (1, 18): 9,
         (1, 19): 12,
         (1, 20): 41,
+        (1, 21): 48,
     }
     latest_pack_format = pack_format_registry[split_version(LATEST_MINECRAFT_VERSION)]
 

--- a/beet/library/resource_pack.py
+++ b/beet/library/resource_pack.py
@@ -50,21 +50,21 @@ from .base import (
 class Blockstate(JsonFile):
     """Class representing a blockstate."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("blockstates",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("blockstates",)]
     extension: ClassVar[str] = ".json"
 
 
 class Model(JsonFile):
     """Class representing a model."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("models",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("models",)]
     extension: ClassVar[str] = ".json"
 
 
 class Language(JsonFile):
     """Class representing a language file."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("lang",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("lang",)]
     extension: ClassVar[str] = ".json"
 
     def merge(self, other: "Language") -> bool:  # type: ignore
@@ -75,7 +75,7 @@ class Language(JsonFile):
 class Font(JsonFile):
     """Class representing a font configuration file."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("font",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("font",)]
     extension: ClassVar[str] = ".json"
 
     def merge(self, other: "Font") -> bool:  # type: ignore
@@ -89,63 +89,63 @@ class Font(JsonFile):
 class GlyphSizes(BinaryFile):
     """Class representing a legacy unicode glyph size file."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("font",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("font",)]
     extension: ClassVar[str] = ".bin"
 
 
 class TrueTypeFont(BinaryFile):
     """Class representing a TrueType font."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("font",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("font",)]
     extension: ClassVar[str] = ".ttf"
 
 
 class ShaderPost(JsonFile):
     """Class representing a shader post-processing pipeline."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("shaders", "post")
+    scope: ClassVar[list[Tuple[str, ...]]] = [("shaders", "post")]
     extension: ClassVar[str] = ".json"
 
 
 class Shader(JsonFile):
     """Class representing a shader."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("shaders",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("shaders",)]
     extension: ClassVar[str] = ".json"
 
 
 class FragmentShader(TextFile):
     """Class representing a fragment shader."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("shaders",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("shaders",)]
     extension: ClassVar[str] = ".fsh"
 
 
 class VertexShader(TextFile):
     """Class representing a vertex shader."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("shaders",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("shaders",)]
     extension: ClassVar[str] = ".vsh"
 
 
 class GlslShader(TextFile):
     """Class representing a glsl shader."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("shaders",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("shaders",)]
     extension: ClassVar[str] = ".glsl"
 
 
 class Text(TextFile):
     """Class representing a text file."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("texts",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("texts",)]
     extension: ClassVar[str] = ".txt"
 
 
 class TextureMcmeta(JsonFile):
     """Class representing a texture mcmeta."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("textures",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("textures",)]
     extension: ClassVar[str] = ".png.mcmeta"
 
 
@@ -156,7 +156,7 @@ class Texture(PngFile):
     content: BinaryFileContent[Image] = None
     mcmeta: Optional[JsonDict] = extra_field(default=None)
 
-    scope: ClassVar[Tuple[str, ...]] = ("textures",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("textures",)]
     extension: ClassVar[str] = ".png"
 
     def bind(self, pack: "ResourcePack", path: str):
@@ -180,7 +180,7 @@ class Sound(BinaryFile):
     attenuation_distance: Optional[int] = extra_field(default=None)
     preload: Optional[bool] = extra_field(default=None)
 
-    scope: ClassVar[Tuple[str, ...]] = ("sounds",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("sounds",)]
     extension: ClassVar[str] = ".ogg"
 
     def bind(self, pack: "ResourcePack", path: str):
@@ -238,14 +238,14 @@ class SoundConfig(JsonFile):
 class Particle(JsonFile):
     """Class representing a particle configuration file."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("particles",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("particles",)]
     extension: ClassVar[str] = ".json"
 
 
 class Atlas(JsonFile):
     """Class representing an atlas configuration file."""
 
-    scope: ClassVar[Tuple[str, ...]] = ("atlases",)
+    scope: ClassVar[list[Tuple[str, ...]]] = [("atlases",)]
     extension: ClassVar[str] = ".json"
 
     def merge(self, other: "Atlas") -> bool:  # type: ignore
@@ -340,6 +340,7 @@ class ResourcePack(Pack[ResourcePackNamespace]):
         (1, 18): 8,
         (1, 19): 13,
         (1, 20): 32,
+        (1, 21): 34
     }
     latest_pack_format = pack_format_registry[split_version(LATEST_MINECRAFT_VERSION)]
 

--- a/beet/library/resource_pack.py
+++ b/beet/library/resource_pack.py
@@ -50,21 +50,21 @@ from .base import (
 class Blockstate(JsonFile):
     """Class representing a blockstate."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("blockstates",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("blockstates",),)
     extension: ClassVar[str] = ".json"
 
 
 class Model(JsonFile):
     """Class representing a model."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("models",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("models",),)
     extension: ClassVar[str] = ".json"
 
 
 class Language(JsonFile):
     """Class representing a language file."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("lang",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("lang",),)
     extension: ClassVar[str] = ".json"
 
     def merge(self, other: "Language") -> bool:  # type: ignore
@@ -75,7 +75,7 @@ class Language(JsonFile):
 class Font(JsonFile):
     """Class representing a font configuration file."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("font",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("font",),)
     extension: ClassVar[str] = ".json"
 
     def merge(self, other: "Font") -> bool:  # type: ignore
@@ -89,63 +89,63 @@ class Font(JsonFile):
 class GlyphSizes(BinaryFile):
     """Class representing a legacy unicode glyph size file."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("font",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("font",),)
     extension: ClassVar[str] = ".bin"
 
 
 class TrueTypeFont(BinaryFile):
     """Class representing a TrueType font."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("font",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("font",),)
     extension: ClassVar[str] = ".ttf"
 
 
 class ShaderPost(JsonFile):
     """Class representing a shader post-processing pipeline."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("shaders", "post")]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("shaders", "post"),)
     extension: ClassVar[str] = ".json"
 
 
 class Shader(JsonFile):
     """Class representing a shader."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("shaders",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("shaders",),)
     extension: ClassVar[str] = ".json"
 
 
 class FragmentShader(TextFile):
     """Class representing a fragment shader."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("shaders",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("shaders",),)
     extension: ClassVar[str] = ".fsh"
 
 
 class VertexShader(TextFile):
     """Class representing a vertex shader."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("shaders",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("shaders",),)
     extension: ClassVar[str] = ".vsh"
 
 
 class GlslShader(TextFile):
     """Class representing a glsl shader."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("shaders",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("shaders",),)
     extension: ClassVar[str] = ".glsl"
 
 
 class Text(TextFile):
     """Class representing a text file."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("texts",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("texts",),)
     extension: ClassVar[str] = ".txt"
 
 
 class TextureMcmeta(JsonFile):
     """Class representing a texture mcmeta."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("textures",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("textures",),)
     extension: ClassVar[str] = ".png.mcmeta"
 
 
@@ -156,7 +156,7 @@ class Texture(PngFile):
     content: BinaryFileContent[Image] = None
     mcmeta: Optional[JsonDict] = extra_field(default=None)
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("textures",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("textures",),)
     extension: ClassVar[str] = ".png"
 
     def bind(self, pack: "ResourcePack", path: str):
@@ -180,7 +180,7 @@ class Sound(BinaryFile):
     attenuation_distance: Optional[int] = extra_field(default=None)
     preload: Optional[bool] = extra_field(default=None)
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("sounds",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("sounds",),)
     extension: ClassVar[str] = ".ogg"
 
     def bind(self, pack: "ResourcePack", path: str):
@@ -238,14 +238,14 @@ class SoundConfig(JsonFile):
 class Particle(JsonFile):
     """Class representing a particle configuration file."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("particles",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("particles",),)
     extension: ClassVar[str] = ".json"
 
 
 class Atlas(JsonFile):
     """Class representing an atlas configuration file."""
 
-    scope: ClassVar[list[Tuple[str, ...]]] = [("atlases",)]
+    scope: ClassVar[Tuple[Tuple[str, ...], ...]] = (("atlases",),)
     extension: ClassVar[str] = ".json"
 
     def merge(self, other: "Atlas") -> bool:  # type: ignore


### PR DESCRIPTION
This PR adds support for the 1.21 renames while still supporting the ability to load older formatted packs. 
This is done by adding the ability for resources to have multiple scopes. 
When listing files, a call is made to check which scope should be used as the output. On pack formats <= 44, it picks the plural and 45+ picks the singular