### PR TITLE
fix: implicit string concat makes the regex bad

### DIFF
--- a/beet/contrib/vanilla.py
+++ b/beet/contrib/vanilla.py
@@ -212,9 +212,8 @@ class ReleaseRegistry(Container[str, Release]):
 
     def missing(self, key: str) -> Release:
         pattern = re.compile(
-            "^"
             "|".join(
-                r"\d+".join(map(re.escape, k.split("*")))
+                "^" + r"\d+".join(map(re.escape, k.split("*")))
                 for k in {key, key.removesuffix(".*")}
             )
             + "$"


### PR DESCRIPTION
I had 50% failure on build, with a KeyError on the beet.contrig.vanilla plugin, this was due to the runtime order of the set : 
```python
{key, key.removesuffix(".*")}
```
Then I found this regex that used implicit string concatenation, I think I fixed it the right way. 