### PR TITLE
fix: updated contrib.installation_advancement to work in 1.20.5+

### DIFF
--- a/beet/contrib/installation_advancement.py
+++ b/beet/contrib/installation_advancement.py
@@ -19,7 +19,7 @@ from beet.core.utils import JsonDict, TextComponent, normalize_string
 
 
 class InstallationAdvancementOptions(PluginOptions):
-    icon: JsonDict = {"item": "minecraft:apple"}
+    icon: JsonDict = {"id": "minecraft:apple"}
     author_namespace: Optional[str] = None
     author_description: str = ""
     author_skull_owner: Optional[str] = None
@@ -66,7 +66,7 @@ def create_root_advancement():
             "display": {
                 "title": "Installed Datapacks",
                 "description": "",
-                "icon": {"item": "minecraft:knowledge_book"},
+                "icon": {"id": "minecraft:knowledge_book"},
                 "background": "minecraft:textures/block/gray_concrete.png",
                 "show_toast": False,
                 "announce_to_chat": False,
@@ -87,8 +87,8 @@ def create_author_advancement(
                 "title": author,
                 "description": author_description,
                 "icon": {
-                    "item": "minecraft:player_head",
-                    "nbt": f"{{'SkullOwner': '{skull_owner}'}}",
+                    "id": "minecraft:player_head",
+                    "components": {"minecraft:profile": {"name": skull_owner}},
                 },
                 "show_toast": False,
                 "announce_to_chat": False,

--- a/examples/installation_advancement/beet.json
+++ b/examples/installation_advancement/beet.json
@@ -6,8 +6,10 @@
   "meta": {
     "installation_advancement": {
       "icon": {
-        "item": "minecraft:red_mushroom",
-        "nbt": "{Enchantments:[{}]}"
+        "id": "minecraft:red_mushroom",
+        "components": {
+          "enchantments": {"protection": 1}
+        }
       },
       "author_description": "Organization behind the beet project"
     }

--- a/tests/snapshots/examples__build_installation_advancement__0.data_pack/data/global/advancement/mcbeet.json
+++ b/tests/snapshots/examples__build_installation_advancement__0.data_pack/data/global/advancement/mcbeet.json
@@ -3,8 +3,12 @@
     "title": "mcbeet",
     "description": "Organization behind the beet project",
     "icon": {
-      "item": "minecraft:player_head",
-      "nbt": "{'SkullOwner': 'mcbeet'}"
+      "id": "minecraft:player_head",
+      "components": {
+        "minecraft:profile": {
+          "name": "mcbeet"
+        }
+      }
     },
     "show_toast": false,
     "announce_to_chat": false

--- a/tests/snapshots/examples__build_installation_advancement__0.data_pack/data/global/advancement/root.json
+++ b/tests/snapshots/examples__build_installation_advancement__0.data_pack/data/global/advancement/root.json
@@ -3,7 +3,7 @@
     "title": "Installed Datapacks",
     "description": "",
     "icon": {
-      "item": "minecraft:knowledge_book"
+      "id": "minecraft:knowledge_book"
     },
     "background": "minecraft:textures/block/gray_concrete.png",
     "show_toast": false,

--- a/tests/snapshots/examples__build_installation_advancement__0.data_pack/data/mcbeet/advancement/example/installed.json
+++ b/tests/snapshots/examples__build_installation_advancement__0.data_pack/data/mcbeet/advancement/example/installed.json
@@ -3,8 +3,12 @@
     "title": "Example",
     "description": "An example project",
     "icon": {
-      "item": "minecraft:red_mushroom",
-      "nbt": "{Enchantments:[{}]}"
+      "id": "minecraft:red_mushroom",
+      "components": {
+        "enchantments": {
+          "protection": 1
+        }
+      }
     },
     "announce_to_chat": false,
     "show_toast": false


### PR DESCRIPTION
The beet.contrib.installation_advancement plugin still uses the old pre-component syntax for items in advancements, and only works up to 1.20.4. This PR updates it to work in 1.20.5+