### PR TITLE
fix: populate context from config

### DIFF
--- a/beet/toolchain/project.py
+++ b/beet/toolchain/project.py
@@ -274,6 +274,26 @@ class ProjectBuilder:
                 whitelist=self.config.whitelist,
             )
 
+            # populate ctx.pack with config info
+            if self.config.data_pack.pack_format:
+                ctx.data.pack_format = self.config.data_pack.pack_format
+            if self.config.data_pack.name:
+                ctx.data.name = self.config.data_pack.name
+            if self.config.data_pack.description:
+                ctx.data.description = self.config.data_pack.description
+            if self.config.data_pack.supported_formats:
+                ctx.data.supported_formats = self.config.data_pack.supported_formats
+            if self.config.resource_pack.pack_format:
+                ctx.assets.pack_format = self.config.resource_pack.pack_format
+            if self.config.resource_pack.name:
+                ctx.assets.name = self.config.resource_pack.name
+            if self.config.resource_pack.description:
+                ctx.assets.description = self.config.resource_pack.description
+            if self.config.resource_pack.supported_formats:
+                ctx.assets.supported_formats = (
+                    self.config.resource_pack.supported_formats
+                )
+
             plugins: List[PluginSpec] = [self.bootstrap]
             plugins.extend(
                 (

--- a/beet/toolchain/project.py
+++ b/beet/toolchain/project.py
@@ -307,36 +307,6 @@ class ProjectBuilder:
         for plugin in plugins:
             ctx.require(plugin)
 
-        pack_configs = [self.config.resource_pack, self.config.data_pack]
-        pack_suffixes = ["_resource_pack", "_data_pack"]
-
-        for config, pack in zip(pack_configs, ctx.packs):
-            if config.name:
-                pack.name = config.name
-            if config.description:
-                pack.description = config.description
-            if config.pack_format:
-                pack.pack_format = config.pack_format
-            if config.supported_formats:
-                pack.supported_formats = config.supported_formats
-
-        ctx.require(
-            load(
-                resource_pack=self.config.resource_pack.load,
-                data_pack=self.config.data_pack.load,
-            )
-        )
-
-        ctx.require(
-            render(
-                resource_pack=self.config.resource_pack.render,
-                data_pack=self.config.data_pack.render,
-            )
-        )
-
-        with log_time("Run pipeline."):
-            yield
-
         description_parts = [
             ctx.project_description if isinstance(ctx.project_description, str) else "",
             ctx.project_author and f"Author: {ctx.project_author}",
@@ -348,6 +318,9 @@ class ProjectBuilder:
             description = list(
                 intersperse(filter(None, [ctx.project_description, description]), "\n")
             )
+
+        pack_configs = [self.config.resource_pack, self.config.data_pack]
+        pack_suffixes = ["_resource_pack", "_data_pack"]
 
         for config, suffix, pack in zip(pack_configs, pack_suffixes, ctx.packs):
             default_name = ctx.project_id
@@ -387,6 +360,23 @@ class ProjectBuilder:
             pack.zipped = bool(config.zipped)
             pack.compression = config.compression
             pack.compression_level = config.compression_level
+
+        ctx.require(
+            load(
+                resource_pack=self.config.resource_pack.load,
+                data_pack=self.config.data_pack.load,
+            )
+        )
+
+        ctx.require(
+            render(
+                resource_pack=self.config.resource_pack.render,
+                data_pack=self.config.data_pack.render,
+            )
+        )
+
+        with log_time("Run pipeline."):
+            yield
 
     def __call__(self, ctx: Context):
         """The builder instance is itself a plugin used for merging subpipelines."""

--- a/beet/toolchain/project.py
+++ b/beet/toolchain/project.py
@@ -274,26 +274,6 @@ class ProjectBuilder:
                 whitelist=self.config.whitelist,
             )
 
-            # populate ctx.pack with config info
-            if self.config.data_pack.pack_format:
-                ctx.data.pack_format = self.config.data_pack.pack_format
-            if self.config.data_pack.name:
-                ctx.data.name = self.config.data_pack.name
-            if self.config.data_pack.description:
-                ctx.data.description = self.config.data_pack.description
-            if self.config.data_pack.supported_formats:
-                ctx.data.supported_formats = self.config.data_pack.supported_formats
-            if self.config.resource_pack.pack_format:
-                ctx.assets.pack_format = self.config.resource_pack.pack_format
-            if self.config.resource_pack.name:
-                ctx.assets.name = self.config.resource_pack.name
-            if self.config.resource_pack.description:
-                ctx.assets.description = self.config.resource_pack.description
-            if self.config.resource_pack.supported_formats:
-                ctx.assets.supported_formats = (
-                    self.config.resource_pack.supported_formats
-                )
-
             plugins: List[PluginSpec] = [self.bootstrap]
             plugins.extend(
                 (
@@ -329,6 +309,16 @@ class ProjectBuilder:
 
         pack_configs = [self.config.resource_pack, self.config.data_pack]
         pack_suffixes = ["_resource_pack", "_data_pack"]
+
+        for config, pack in zip(pack_configs, ctx.packs):
+            if config.name:
+                pack.name = config.name
+            if config.description:
+                pack.description = config.description
+            if config.pack_format:
+                pack.pack_format = config.pack_format
+            if config.supported_formats:
+                pack.supported_formats = config.supported_formats
 
         ctx.require(
             load(

--- a/tests/ctx_config_examples/mcmeta/beet.json
+++ b/tests/ctx_config_examples/mcmeta/beet.json
@@ -1,0 +1,18 @@
+{
+  "data_pack": {
+    "name": "My Data Pack",
+    "description": "a data pack",
+    "pack_format": 6,
+    "supported_formats": [0,6]
+  },
+  "resource_pack": {
+    "name": "My Resource Pack",
+    "description": "a resource pack",
+    "pack_format": 10,
+    "supported_formats": {
+      "min_inclusive": 10,
+      "max_inclusive": 20
+    }
+  },
+  "pipeline": ["mcmeta"]
+}

--- a/tests/ctx_config_examples/mcmeta/mcmeta.py
+++ b/tests/ctx_config_examples/mcmeta/mcmeta.py
@@ -1,0 +1,9 @@
+from beet import Context
+
+
+def beet_default(ctx: Context):
+    all = [
+        f"{ctx.data.mcmeta.data}",
+        f"{ctx.assets.mcmeta.data}",
+    ]
+    ctx.meta["pytest"] = "\n".join(all) + "\n"

--- a/tests/ctx_config_examples/pack_info/beet.json
+++ b/tests/ctx_config_examples/pack_info/beet.json
@@ -1,0 +1,18 @@
+{
+  "data_pack": {
+    "name": "My Data Pack",
+    "description": "a data pack",
+    "pack_format": 6,
+    "supported_formats": [0,6]
+  },
+  "resource_pack": {
+    "name": "My Resource Pack",
+    "description": "a resource pack",
+    "pack_format": 10,
+    "supported_formats": {
+      "min_inclusive": 10,
+      "max_inclusive": 20
+    }
+  },
+  "pipeline": ["pack_info"]
+}

--- a/tests/ctx_config_examples/pack_info/pack_info.py
+++ b/tests/ctx_config_examples/pack_info/pack_info.py
@@ -1,0 +1,15 @@
+from beet import Context
+
+
+def beet_default(ctx: Context):
+    all = [
+        f"{ctx.data.name}",
+        f"{ctx.data.description}",
+        f"{ctx.data.pack_format}",
+        f"{ctx.data.supported_formats}",
+        f"{ctx.assets.name}",
+        f"{ctx.assets.description}",
+        f"{ctx.assets.pack_format}",
+        f"{ctx.assets.supported_formats}",
+    ]
+    ctx.meta["pytest"] = "\n".join(all) + "\n"

--- a/tests/ctx_config_examples/project_info/beet.json
+++ b/tests/ctx_config_examples/project_info/beet.json
@@ -1,0 +1,9 @@
+{
+  "author": "somebody",
+  "version": "1.2.3",
+  "name": "BEET",
+  "id": "beet",
+  "description": "a beet project",
+  "minecraft": "1.19",
+  "pipeline": ["project_info"]
+}

--- a/tests/ctx_config_examples/project_info/project_info.py
+++ b/tests/ctx_config_examples/project_info/project_info.py
@@ -1,0 +1,13 @@
+from beet import Context
+
+
+def beet_default(ctx: Context):
+    all = [
+        f"{ctx.minecraft_version}",
+        f"{ctx.project_author}",
+        f"{ctx.project_description}",
+        f"{ctx.project_id}",
+        f"{ctx.project_name}",
+        f"{ctx.project_version}",
+    ]
+    ctx.meta["pytest"] = "\n".join(all) + "\n"

--- a/tests/snapshots/ctx_config__examples_mcmeta__0.txt
+++ b/tests/snapshots/ctx_config__examples_mcmeta__0.txt
@@ -1,0 +1,2 @@
+{'pack': {'pack_format': 6, 'description': 'a data pack', 'supported_formats': [0, 6]}}
+{'pack': {'pack_format': 10, 'description': 'a resource pack', 'supported_formats': {'min_inclusive': 10, 'max_inclusive': 20}}}

--- a/tests/snapshots/ctx_config__examples_pack_info__0.txt
+++ b/tests/snapshots/ctx_config__examples_pack_info__0.txt
@@ -1,0 +1,8 @@
+My Data Pack
+a data pack
+6
+[0, 6]
+My Resource Pack
+a resource pack
+10
+{'min_inclusive': 10, 'max_inclusive': 20}

--- a/tests/snapshots/ctx_config__examples_project_info__0.txt
+++ b/tests/snapshots/ctx_config__examples_project_info__0.txt
@@ -1,0 +1,6 @@
+1.19
+somebody
+a beet project
+beet
+BEET
+1.2.3

--- a/tests/snapshots/examples__build_load_overlay__0.data_pack/pack.mcmeta
+++ b/tests/snapshots/examples__build_load_overlay__0.data_pack/pack.mcmeta
@@ -12,6 +12,13 @@
     "entries": [
       {
         "formats": {
+          "min_inclusive": 18,
+          "max_inclusive": 19
+        },
+        "directory": "creeper"
+      },
+      {
+        "formats": {
           "min_inclusive": 17,
           "max_inclusive": 18
         },
@@ -27,13 +34,6 @@
       {
         "formats": 19,
         "directory": "overlay_missing"
-      },
-      {
-        "formats": {
-          "min_inclusive": 18,
-          "max_inclusive": 19
-        },
-        "directory": "creeper"
       }
     ]
   }

--- a/tests/snapshots/examples__build_load_pack_filter__0.data_pack/pack.mcmeta
+++ b/tests/snapshots/examples__build_load_pack_filter__0.data_pack/pack.mcmeta
@@ -6,14 +6,14 @@
   "filter": {
     "block": [
       {
+        "namespace": "minecraft"
+      },
+      {
         "namespace": "foo",
         "path": "bar"
       },
       {
         "namespace": "thing"
-      },
-      {
-        "namespace": "minecraft"
       }
     ]
   }

--- a/tests/test_ctx_config.py
+++ b/tests/test_ctx_config.py
@@ -1,0 +1,12 @@
+import os
+
+import pytest
+from pytest_insta import SnapshotFixture
+
+from beet import run_beet
+
+
+@pytest.mark.parametrize("directory", os.listdir("tests/ctx_config_examples"))
+def test_examples(snapshot: SnapshotFixture, directory: str):
+    with run_beet(directory=f"tests/ctx_config_examples/{directory}") as ctx:
+        assert snapshot() == f'{ctx.meta["pytest"]}'


### PR DESCRIPTION
- fix #451 
- populate ctx.data and ctx.assets with the following info from the config:
  - name
  - description
  - pack_format
  - supported_formats