### PR TITLE
fix: Pack.all returning duplicate files in overlays

### DIFF
--- a/beet/library/base.py
+++ b/beet/library/base.py
@@ -1250,12 +1250,12 @@ class Pack(MatchMixin, MergeMixin, Container[str, NamespaceType]):
             proxy = self[file_type]
             for path in proxy.match(*match or ["*"]):
                 yield path, proxy[path]
-            if self.overlay_parent is None:
-                for overlay in self.overlays.values():
-                    if extend:
-                        yield from overlay.all(*match, extend=extend)
-                    else:
-                        yield from overlay.all(*match)
+        if self.overlay_parent is None:
+            for overlay in self.overlays.values():
+                if extend:
+                    yield from overlay.all(*match, extend=extend)
+                else:
+                    yield from overlay.all(*match)
 
     @property
     def supported_formats(self) -> Optional[SupportedFormats]:


### PR DESCRIPTION
If you had a pack like this
![image](https://github.com/user-attachments/assets/c47ad66a-6774-40e2-91de-8507e06ee1e4)

Running `ctx.data.all()` would return duplicates of each overlay file, once for each file type:
![image](https://github.com/user-attachments/assets/da98c0d6-608c-4ee6-8427-f33cf1a90946)
