### PR TITLE
chore: improve datapack update by testing NamespaceFileType

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,7 @@
     "editor.formatOnType": false,
     "editor.formatOnPaste": false,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+      "source.organizeImports": "explicit"
     },
     "editor.defaultFormatter": "ms-python.black-formatter"
   }

--- a/beet/contrib/worldgen.py
+++ b/beet/contrib/worldgen.py
@@ -18,11 +18,14 @@ __all__ = [
     "WorldgenTemplatePool",
     "WorldgenWorldPreset",
     "WorldgenFlatLevelGeneratorPreset",
+    "WorldgenMultiNoiseBiomeSourceParameterList",
     "WorldgenBiomeTag",
     "WorldgenStructureSetTag",
     "WorldgenStructureTag",
     "WorldgenConfiguredCarverTag",
     "WorldgenPlacedFeatureTag",
+    "WorldgenFlatLevelGeneratorPresetTag",
+    "WorldgenWorldPresetTag",
 ]
 
 

--- a/beet/contrib/worldgen.py
+++ b/beet/contrib/worldgen.py
@@ -56,11 +56,14 @@ def worldgen(pack: Union[Context, DataPack]):
         WorldgenTemplatePool,
         WorldgenWorldPreset,
         WorldgenFlatLevelGeneratorPreset,
+        WorldgenMultiNoiseBiomeSourceParameterList,
         WorldgenBiomeTag,
         WorldgenStructureSetTag,
         WorldgenStructureTag,
         WorldgenConfiguredCarverTag,
         WorldgenPlacedFeatureTag,
+        WorldgenFlatLevelGeneratorPresetTag,
+        WorldgenWorldPresetTag,
     ]
 
 
@@ -176,6 +179,16 @@ class WorldgenFlatLevelGeneratorPreset(JsonFile):
     extension: ClassVar[str] = ".json"
 
 
+class WorldgenMultiNoiseBiomeSourceParameterList(JsonFile):
+    """Class representing a worldgen multi noise biome source parameter list."""
+
+    scope: ClassVar[NamespaceFileScope] = (
+        "worldgen",
+        "multi_noise_biome_source_parameter_list",
+    )
+    extension: ClassVar[str] = ".json"
+
+
 class WorldgenBiomeTag(TagFile):
     """Class representing a biome tag."""
 
@@ -204,3 +217,20 @@ class WorldgenPlacedFeatureTag(TagFile):
     """Class representing a worldgen placed feature tag."""
 
     scope: ClassVar[NamespaceFileScope] = ("tags", "worldgen", "placed_feature")
+
+
+class WorldgenFlatLevelGeneratorPresetTag(TagFile):
+    """Class representing a worldgen flat level generator preset tag."""
+
+    scope: ClassVar[NamespaceFileScope] = (
+        "tags",
+        "worldgen",
+        "flat_level_generator_preset",
+    )
+
+
+# world_preset
+class WorldgenWorldPresetTag(TagFile):
+    """Class representing a worldgen world preset tag."""
+
+    scope: ClassVar[NamespaceFileScope] = ("tags", "worldgen", "world_preset")

--- a/beet/library/resource_pack.py
+++ b/beet/library/resource_pack.py
@@ -163,6 +163,13 @@ class Text(TextFile):
     extension: ClassVar[str] = ".txt"
 
 
+class TextJson(JsonFile):
+    """Class representing a json file in the texts folder (only used for credits.json)."""
+
+    scope: ClassVar[NamespaceFileScope] = ("texts",)
+    extension: ClassVar[str] = ".json"
+
+
 class TextureMcmeta(JsonFile):
     """Class representing a texture mcmeta."""
 
@@ -337,6 +344,7 @@ class ResourcePackNamespace(Namespace):
     vertex_shaders:   NamespacePin[VertexShader]   = NamespacePin(VertexShader)
     glsl_shaders:     NamespacePin[GlslShader]     = NamespacePin(GlslShader)
     texts:            NamespacePin[Text]           = NamespacePin(Text)
+    texts_json:       NamespacePin[TextJson]       = NamespacePin(TextJson)
     textures_mcmeta:  NamespacePin[TextureMcmeta]  = NamespacePin(TextureMcmeta)
     textures:         NamespacePin[Texture]        = NamespacePin(Texture)
     sounds:           NamespacePin[Sound]          = NamespacePin(Sound)
@@ -392,6 +400,7 @@ class ResourcePack(Pack[ResourcePackNamespace]):
     vertex_shaders:   NamespaceProxyDescriptor[VertexShader]   = NamespaceProxyDescriptor(VertexShader)
     glsl_shaders:     NamespaceProxyDescriptor[GlslShader]     = NamespaceProxyDescriptor(GlslShader)
     texts:            NamespaceProxyDescriptor[Text]           = NamespaceProxyDescriptor(Text)
+    texts_json:       NamespaceProxyDescriptor[TextJson]       = NamespaceProxyDescriptor(TextJson)
     textures_mcmeta:  NamespaceProxyDescriptor[TextureMcmeta]  = NamespaceProxyDescriptor(TextureMcmeta)
     textures:         NamespaceProxyDescriptor[Texture]        = NamespaceProxyDescriptor(Texture)
     sounds:           NamespaceProxyDescriptor[Sound]          = NamespaceProxyDescriptor(Sound)

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -1,0 +1,55 @@
+from beet.contrib.vanilla import Vanilla
+from beet.contrib.unknown_files import UnknownAsset, UnknownData
+import tempfile
+
+from beet.core.cache import Cache
+from beet.library.base import LATEST_MINECRAFT_VERSION
+from beet.toolchain.helpers import run_beet
+from zipfile import ZipFile
+
+
+def test_namespaces():
+    # Test that all namespaces are known
+    # It loads the vanilla jar and checks
+    # that there are no unknown namespaces
+    with tempfile.TemporaryDirectory() as dir:
+        cache = Cache(dir)
+        vanilla = Vanilla(cache=cache, minecraft_version=LATEST_MINECRAFT_VERSION)
+        client_jar = vanilla.mount()
+        with run_beet(
+            {
+                "require": ["beet.contrib.unknown_files"],
+                "output": "build",
+            },
+        ) as ctx:
+            # We loads directly from the jar file
+            ctx.data.load(ZipFile(client_jar.path))
+            ctx.assets.load(ZipFile(client_jar.path))
+
+            known_assets: set[str] = {
+                "minecraft:gpu_warnlist.json",
+                "minecraft:regional_compliancies.json",
+            }
+            unknown_assets: list[str] = []
+            for x in ctx.assets[UnknownAsset].keys():
+                if x in known_assets:
+                    continue
+                unknown_assets.append(x)
+            if unknown_assets:
+                raise ValueError(
+                    f"An unknown asset has no NamespaceFileType: {unknown_assets}"
+                )
+
+            known_data: set[str] = set()
+            unknown_data: list[str] = []
+            for x in ctx.data[UnknownData].keys():
+                if x in known_data:
+                    continue
+                if x.startswith("minecraft:datapacks/"):
+                    # We ignore datapacks
+                    continue
+                unknown_data.append(x)
+            if unknown_data:
+                raise ValueError(
+                    f"An unknown data has no NamespaceFileType: {unknown_data}"
+                )


### PR DESCRIPTION
This PR adds somes worldgen specific namespaces and a new test.

The new test improve beet update when mojang adds a new folder (recently the `items` folder). It's checking that when loading the vanilla resouce pack and data pack there is no unknown files.

I'm not sure that it's the good way of doing it thought.