### PR TITLE
Created the creative loot tables plugin

### DIFF
--- a/beet/contrib/creative_loot_tables.py
+++ b/beet/contrib/creative_loot_tables.py
@@ -1,0 +1,30 @@
+"""Plugin that automates the creation of the creative loot table"""
+# IMPORTANT : this plugin is meant to be used with the mod https://modrinth.com/mod/creative-loot-tables
+# USAGE: in your beet.json file, specify a regex at meta.creative_loot_tables.pattern
+# any loot table with an ID matching with this regex will be put in the creative loot table.
+
+from beet import Context, LootTable
+from re import Pattern
+import re
+
+def beet_default(ctx: Context) -> None:
+    
+    # get the pattern
+    meta: dict = ctx.meta
+    pattern: str = meta.get("creative_loot_tables", {}).get("pattern")
+    if pattern is None:
+        return
+    regex: Pattern = re.compile(pattern)
+   
+    # search
+    loot_tables: list[str] = [id for id in ctx.data.loot_tables if regex.match(id)]
+
+    # no match found
+    if len(loot_tables) == 0:
+        return
+    
+    # output the loot table
+    creative_loot_table: dict = {
+        "pools": [{"rolls": 1, "entries": [{"type": "loot_table", "value": loot_table}] } for loot_table in loot_tables]
+    }
+    ctx.generate("creative_loot_tables:creative_loot_table", LootTable(creative_loot_table))


### PR DESCRIPTION
## What does it do ?
With the new [creative loot tables mod](https://modrinth.com/mod/creative-loot-tables), datapack creators and users can now easily access custom items via a menu.
## Example
- Create a set of loot tables at `namespace:item/...`, and another at `namespace:weapon/...`
- In your `beet.json`, in the `meta` field, write :
```
json
"creative_loot_tables": {
  "pattern": ".*(item|weapon)/.*"
}
```
- append `"beet.contrib.creative_loot_tables"` to your `pipeline` list
- Build the project, and load the datapack with the creative loot tables mod in creative mode
- Open the creative inventory; the custom items will be in the tab with a bundle icon.
## Why ?
Having this plugin is a much more convenient way to use the mod, as without it, you have to manually append each loot table to the creative loot table. Now a single regex does all the work for you.