### PR TITLE
feat: beet.contrib.bake_overlays

### DIFF
--- a/beet/contrib/bake_overlays.py
+++ b/beet/contrib/bake_overlays.py
@@ -1,0 +1,93 @@
+import logging
+from dataclasses import replace
+from typing import TypeVar
+
+from beet import Context
+
+from ..core.utils import SupportedFormats
+from ..library.data_pack import DataPack
+from ..library.resource_pack import ResourcePack
+from ..toolchain.context import PluginOptions, configurable
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", DataPack, ResourcePack)
+
+
+class BakeOverlayOptions(PluginOptions):
+    selected_data_format: int | None = None
+    selected_assets_format: int | None = None
+
+
+def bake_overlay(pack: T, overlay: T):
+    """Bake an overlay onto an original pack."""
+
+    original_policy = pack.merge_policy
+    pack.merge_policy = replace(
+        pack.merge_policy,
+        namespace={namespace: [] for namespace in pack.get_file_types()},
+    )
+
+    pack.merge(overlay)
+
+    pack.merge_policy = original_policy
+
+
+def bake_overlays_for_pack_format(pack: T, pack_format: int):
+    """Procedurally bake overlays conditionally based on a specific pack format that is supported.
+
+    All overlays are then cleared from the original pack.
+    """
+
+    for name, overlay in pack.overlays.items():
+        if overlay.supported_formats is None:
+            continue
+
+        if check_formats(overlay.supported_formats, pack_format):
+            logger.info(f"Baking overlay '{name}'")
+            bake_overlay(pack, overlay)
+
+    pack.overlays.clear()
+
+
+@configurable(validator=BakeOverlayOptions)
+def bake_overlays(ctx: Context, opts: BakeOverlayOptions):
+    """This plugin will bake overlays based upon a selected pack format for both
+    data and resource packs (if they have files).
+
+    If a format is not presented, the default will be chosen from the latest pack format available.
+    """
+
+    if opts.selected_data_format is None:
+        opts.selected_data_format = ctx.data.pack_format
+
+    if opts.selected_assets_format is None:
+        opts.selected_assets_format = ctx.assets.pack_format
+
+    if len(ctx.data) > 0:
+        bake_overlays_for_pack_format(ctx.data, opts.selected_data_format)
+
+    if len(ctx.assets) > 0:
+        bake_overlays_for_pack_format(ctx.assets, opts.selected_assets_format)
+
+
+def check_formats(supported: SupportedFormats, pack_format: int) -> bool:
+    """Checks whether a pack format is supported for a pack
+
+    Originally adapted from:
+    https://github.com/Gamemode4Dev/GM4_Datapacks/blob/master/gm4/plugins/backwards.py#L168-L177
+    """
+
+    match supported:
+        case int(value):
+            return value == pack_format
+        case [min, max]:
+            return min <= pack_format <= max
+        case {"min_inclusive": min, "max_inclusive": max}:
+            return min <= pack_format <= max
+        case _:
+            raise ValueError(f"Unknown supported formats structure {supported}")
+
+
+def beet_default(ctx: Context):
+    ctx.require(bake_overlays)

--- a/examples/load_overlay_baked/beet.yml
+++ b/examples/load_overlay_baked/beet.yml
@@ -1,0 +1,8 @@
+data_pack:
+  load: "src"
+
+pipeline: [beet.contrib.bake_overlays]
+
+meta:
+  bake_overlays:
+    selected_data_format: 18

--- a/examples/load_overlay_baked/src/data/demo/functions/foo.mcfunction
+++ b/examples/load_overlay_baked/src/data/demo/functions/foo.mcfunction
@@ -1,0 +1,1 @@
+say hello base

--- a/examples/load_overlay_baked/src/data/demo/minecraft/tags/functions/load.json
+++ b/examples/load_overlay_baked/src/data/demo/minecraft/tags/functions/load.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "demo:foo"
+    ]
+}

--- a/examples/load_overlay_baked/src/overlay1/data/demo/functions/foo.mcfunction
+++ b/examples/load_overlay_baked/src/overlay1/data/demo/functions/foo.mcfunction
@@ -1,0 +1,1 @@
+say hello overlay-17-18

--- a/examples/load_overlay_baked/src/overlay1/data/minecraft/tags/functions/load.json
+++ b/examples/load_overlay_baked/src/overlay1/data/minecraft/tags/functions/load.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "demo:foo2"
+    ]
+}

--- a/examples/load_overlay_baked/src/overlay2/data/demo/functions/foo.mcfunction
+++ b/examples/load_overlay_baked/src/overlay2/data/demo/functions/foo.mcfunction
@@ -1,0 +1,1 @@
+say hello overlay-19-20

--- a/examples/load_overlay_baked/src/overlay_extra/data/demo/functions/foo.mcfunction
+++ b/examples/load_overlay_baked/src/overlay_extra/data/demo/functions/foo.mcfunction
@@ -1,0 +1,1 @@
+say extra

--- a/examples/load_overlay_baked/src/pack.mcmeta
+++ b/examples/load_overlay_baked/src/pack.mcmeta
@@ -1,0 +1,18 @@
+{
+    "overlays": {
+        "entries": [
+            {
+                "formats": {"min_inclusive": 17, "max_inclusive": 18},
+                "directory": "overlay1"
+            },
+            {
+                "formats": {"min_inclusive": 19, "max_inclusive": 20},
+                "directory": "overlay2"
+            },
+            {
+                "formats": 21,
+                "directory": "overlay_missing"
+            }
+        ]
+    }
+}

--- a/tests/snapshots/examples__build_load_overlay_baked__0.data_pack/data/demo/function/foo.mcfunction
+++ b/tests/snapshots/examples__build_load_overlay_baked__0.data_pack/data/demo/function/foo.mcfunction
@@ -1,0 +1,1 @@
+say hello overlay-17-18

--- a/tests/snapshots/examples__build_load_overlay_baked__0.data_pack/data/minecraft/tags/function/load.json
+++ b/tests/snapshots/examples__build_load_overlay_baked__0.data_pack/data/minecraft/tags/function/load.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "demo:foo2"
+    ]
+}

--- a/tests/snapshots/examples__build_load_overlay_baked__0.data_pack/pack.mcmeta
+++ b/tests/snapshots/examples__build_load_overlay_baked__0.data_pack/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 48,
+    "description": ""
+  }
+}

--- a/tests/snapshots/examples__build_load_overlay_baked__1.resource_pack/pack.mcmeta
+++ b/tests/snapshots/examples__build_load_overlay_baked__1.resource_pack/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 34,
+    "description": ""
+  }
+}


### PR DESCRIPTION
Adds `beet.contrib.bake_overlays` as a new beet plugin to help collapse overlays onto a singular version.

## open questions
- this only handles `namespace` and ignores `extras` and `namespace_extras`
- the naming of the config is a bit odd
- if config isn't available, it pulls from the set `pack.pack_format` which usually pulls from the latest version (actually, if set in `beet.json`, if a `pack.mcmeta` exists, it'll still be the latest if it's still unset).
- the merging temporarily replaces a merge policy with a defunct one. unsure if this is the best route for all merging involved.
- Make plugin also work for generic packs and not just `ctx`