### PR TITLE
ci(docs): Rebuild documentation when changelog is updated

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,7 @@ on:
       - "docs/**"
       - "README.md"
       - "pyproject.toml"
+      - "CHANGELOG.md"
 
 env:
   PYTHON_VERSION: "3.10"


### PR DESCRIPTION
Add CHANGELOG.md to the paths for the docs workflow, as the changelog is a part of the documentation (deployed at: https://mcbeet.dev/changelog/).