### PR TITLE
Fix: include subprojects' ignore and output directories to prevent rebuild loops in watch when using broadcast

### DIFF
--- a/src/beet/toolchain/project.py
+++ b/src/beet/toolchain/project.py
@@ -106,14 +106,18 @@ class Project:
     def ignore(self) -> List[str]:
         ignore = set(self.config.ignore)
         if self.output_directory and self.directory in self.output_directory.parents:
-            ignore.add(f"{self.output_directory.relative_to(self.directory).as_posix()}/")
+            ignore.add(
+                f"{self.output_directory.relative_to(self.directory).as_posix()}/"
+            )
         for entry in self.config.pipeline:
             if isinstance(entry, ProjectConfig):
                 ignore.update(entry.ignore)
                 if entry.output:
                     output_directory = Path(entry.output)
                     if entry.directory in output_directory.parents:
-                        ignore.add(f"{output_directory.relative_to(entry.directory).as_posix()}/")
+                        ignore.add(
+                            f"{output_directory.relative_to(entry.directory).as_posix()}/"
+                        )
         return list(ignore)
 
     @property


### PR DESCRIPTION
This PR fixes an issue where only the main project’s ignore patterns and output directory were considered when building the final ignore list.
As a result, subprojects’ ignore rules and outputs were not excluded properly when using `broadcast`.

**Why it matters**
The ignore list is used by the --watch option to determine which files should trigger rebuilds.
Previously, since subproject build directories were not ignored, any file changes inside them would cause infinite rebuild loops, showing the build triggered repeatedly warning.
This fix prevents that by correctly ignoring all subprojects’ output and ignore paths.

### Changes
- Updated the ignore property to:
  - Include each subproject’s ignore list.
  - Include each subproject’s output directory.
- Deduplicates entries using a set while maintaining the same return type.

### Example
Project structure
```
packs/
├── foo/
│   ├── build/
│   └── beet.yml
├── bar/
│   ├── baz/
│   ├── build/
│   └── beet.yml
└── beet.yml
```
Configs
`packs/foo/beet.yml`
```yml
output: build
```
`packs/bar/beet.yml`
```yml
output: build
ignore:
  - baz
```
`beet.yml`
```yml
broadcast: packs/*
extend: [beet.yml]
```

#### Before
Changes in any of the following directories would cause an infinite rebuild loop:
```
packs/foo/build
packs/bar/build
packs/bar/baz
```

#### After
All subprojects’ `ignore` and `output` directories are properly ignored, and the watch now behaves as expected.