### PR TITLE
fix: better cache handeling by waiting for the result

### DIFF
--- a/beet/core/cache.py
+++ b/beet/core/cache.py
@@ -380,10 +380,19 @@ class DownloadManager:
 
         if not path.is_file():
             fileobj = path.open("wb")
-            if self.executor:
-                self.executor.submit(self.retrieve, arg, fileobj)
-            else:
-                self.retrieve(arg, fileobj)
+            try:
+                if self.executor:
+                    future = self.executor.submit(self.retrieve, arg, fileobj)
+                    future.result()
+                else:
+                    self.retrieve(arg, fileobj)
+            except Exception as e:
+                try:
+                    fileobj.close()
+                    path.unlink()
+                except Exception:
+                    pass
+                raise e
 
         return path
 

--- a/examples/cache_test/beet.yml
+++ b/examples/cache_test/beet.yml
@@ -1,0 +1,6 @@
+meta:
+  vanilla:
+    version: "1.21.8"
+
+pipeline:
+  - mre

--- a/examples/cache_test/mre.py
+++ b/examples/cache_test/mre.py
@@ -1,0 +1,6 @@
+from beet import Context
+from beet.contrib.vanilla import Vanilla
+
+
+def beet_default(ctx: Context):
+    ctx.inject(Vanilla).mount("assets/minecraft/font", fetch_objects=True)

--- a/tests/snapshots/examples__build_cache_test__0.data_pack/pack.mcmeta
+++ b/tests/snapshots/examples__build_cache_test__0.data_pack/pack.mcmeta
@@ -1,0 +1,13 @@
+{
+  "pack": {
+    "min_format": [
+      88,
+      0
+    ],
+    "max_format": [
+      88,
+      0
+    ],
+    "description": ""
+  }
+}

--- a/tests/snapshots/examples__build_cache_test__1.resource_pack/pack.mcmeta
+++ b/tests/snapshots/examples__build_cache_test__1.resource_pack/pack.mcmeta
@@ -1,0 +1,13 @@
+{
+  "pack": {
+    "min_format": [
+      69,
+      0
+    ],
+    "max_format": [
+      69,
+      0
+    ],
+    "description": ""
+  }
+}


### PR DESCRIPTION
This PR fix #479 by waiting for the result, with `future.result()` in case of a multi threading.

I also added better error handling, if there is an exception during the download (internet error for example), the file is deleted with `path.unlink()`