### PR TITLE
Text components became SNBT in 1.21.5, not 1.21

### DIFF
--- a/packages/mecha/src/mecha/parse.py
+++ b/packages/mecha/src/mecha/parse.py
@@ -594,7 +594,7 @@ def get_parsers(version: VersionNumber = LATEST_MINECRAFT_VERSION) -> Dict[str, 
     if version < (1, 20):
         parsers["scoreboard_slot"] = BasicLiteralParser(AstLegacyScoreboardSlot)
 
-    if version < (1, 21):
+    if version < (1, 21, 5):
         parsers["command:argument:minecraft:component"] = MultilineParser(
             delegate("json")
         )


### PR DESCRIPTION
This fixes all text component commands from versions 1.21 to 1.21.4, which previously were incorrectly parsed as SNBT when they should have been JSON.

Fixes mcbeet/beet#503.